### PR TITLE
Update initDispatch arg order in enhancer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ export function withHyperload(nextApp) {
       return [
         initialState,
         [
-          function(_, initDispatch) {
+          function(initDispatch) {
             dispatch = initDispatch;
             dispatch(props.init);
             dispatch(function(state) {


### PR DESCRIPTION
The argument for dispatch in the enhancedInit assignment of initDispatch should be in position 0.